### PR TITLE
Free dynamically allocated BSTR.

### DIFF
--- a/src/inlineExecute-Assembly.c
+++ b/src/inlineExecute-Assembly.c
@@ -438,7 +438,9 @@ void go(char* args, int length) {//Executes .NET assembly in memory
 	for (long i = 0; i < argumentCount; i++)
 	{
 		//Insert the string from argumentsArray[i] into the safearray
-		OLEAUT32$SafeArrayPutElement(vtPsa.parray, &i, OLEAUT32$SysAllocString(argumentsArray[i]));
+      		OLEAUT32$SafeArrayPutElement(vtPsa.parray, &i, bstrArg);
+      		OLEAUT32$SysFreeString( bstrArg );
+		BSTR bstrArg = OLEAUT32$SysAllocString(argumentsArray[i]);
 	}
 		
 	//Break ETW

--- a/src/inlineExecute-Assembly.h
+++ b/src/inlineExecute-Assembly.h
@@ -43,6 +43,7 @@ WINBASEAPI HRESULT WINAPI OLEAUT32$SafeArrayPutElement(SAFEARRAY* psa, LONG* rgI
 WINBASEAPI HRESULT WINAPI OLEAUT32$SafeArrayDestroy(SAFEARRAY* psa);
 WINBASEAPI HRESULT WINAPI OLEAUT32$VariantClear(VARIANTARG* pvarg);
 WINBASEAPI BSTR WINAPI OLEAUT32$SysAllocString(const OLECHAR* psz);
+WINBASEAPI VOID WINAPI OLEAUT32$SysFreeString(BSTR bstrString);
 
 #define intZeroMemory(addr,size) memset((addr),0,size)
 #define intAlloc(size) KERNEL32$HeapAlloc(KERNEL32$GetProcessHeap(), HEAP_ZERO_MEMORY, size)


### PR DESCRIPTION
A dynamically allocated BSTR is being created and passed directly to `SafeArrayPutElement`, which results in a memory leak. This PR captures the BSTR and frees it with `SysFreeString`.